### PR TITLE
fix: remove fallback resource in ThreadManager.m

### DIFF
--- a/ios/ThreadManager.m
+++ b/ios/ThreadManager.m
@@ -20,7 +20,7 @@ RCT_REMAP_METHOD(startThread,
 
   int threadId = abs(arc4random());
 
-  NSURL *threadURL = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:name fallbackResource:name];
+  NSURL *threadURL = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:name];
   NSLog(@"starting Thread %@", [threadURL absoluteString]);
 
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "react-native-threads",
-  "version": "0.0.19",
+  "name": "@atomicfinance/react-native-threads",
+  "version": "0.0.20",
   "description": "",
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git@github.com:joltup/react-native-threads.git"
+    "url": "git@github.com:atomicfinance/react-native-threads.git"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
## What

This PR removes fallbackResource in ThreadManager.m since it no longer exists in RN 68

It also temporarily sets up @atomicfinance/react-native-threads and bumps to 0.0.20 until https://github.com/joltup/react-native-threads is updated to fix this issue

https://github.com/joltup/react-native-threads/issues/147
